### PR TITLE
Partial spanish translation ch05-03-method-syntax.md 2/2

### DIFF
--- a/second-edition/src/ch05-03-method-syntax.md
+++ b/second-edition/src/ch05-03-method-syntax.md
@@ -58,37 +58,37 @@ antes de `self`, tal como hicimos en `&Rectangle`. Los métodos pueden tomar pos
 `self`, prestar a `self` inmutablemente como lo hemos hecho aquí, o prestar a `self` mutablemente, 
 como cualquier otro parámetro.
 
-We’ve chosen `&self` here for the same reason we used `&Rectangle` in the
-function version: we don’t want to take ownership, and we just want to read the
-data in the struct, not write to it. If we wanted to change the instance that
-we’ve called the method on as part of what the method does, we’d use `&mut
-self` as the first parameter. Having a method that takes ownership of the
-instance by using just `self` as the first parameter is rare; this technique is
-usually used when the method transforms `self` into something else and we want
-to prevent the caller from using the original instance after the transformation.
+Hemos escogido el `self` por la misma razón que usamos el `&Rectangle` en la 
+versión funcional: no queremos tomar posesión, y sólo queremos leer los 
+datos en la estructura, no escribirle. Si quisiéramos cambiar la instancia en la
+que hemos llamado al método como parte de lo que hace el método, usaríamos `&mut
+self` como el primer parámetro. Tener un método que se adueña de la 
+instancia usando sólo `self` como el primer parámetro es raro; esta técnica se 
+suele utilizar cuando el método transforma `self` en algo más y queremos 
+evitar que el llamante utilice la instancia original después de la transformación.
 
-The main benefit of using methods instead of functions, in addition to using
-method syntax and not having to repeat the type of `self` in every method’s
-signature, is for organization. We’ve put all the things we can do with an
-instance of a type in one `impl` block rather than making future users of our
-code search for capabilities of `Rectangle` in various places in the library we
-provide.
+El principal beneficio de usar métodos en vez de funciones, además de usar 
+la sintaxis del método y no tener que repetir el tipo de `self` en la firma de 
+cada método, es para la organización. Hemos puesto todas las cosas que podemos hacer con una
+instancia de un tipo en un bloque `impl` en lugar de hacer que los futuros usuarios de nuestro
+código busquen capacidades de `Rectangle` en varios lugares de la biblioteca 
+que proporcionamos.
 
-> ### Where’s the `->` Operator?
+> ### ¿Dónde está el  operador `->`?
 >
-> In languages like C++, two different operators are used for calling methods:
-> you use `.` if you’re calling a method on the object directly and `->` if
-> you’re calling the method on a pointer to the object and need to dereference
-> the pointer first. In other words, if `object` is a pointer,
-> `object->something()` is similar to `(*object).something()`.
+> En lenguajes como C++, se utilizan dos operadores diferentes para llamar a métodos: 
+> usas `.` si se llama a un método en el objeto directamente y `->` si
+> llamas al método en un puntero al objeto y necesitas desreferenciar 
+> el puntero primero. En otras palabras, si `object`  es un puntero,
+> `object->something()` es similar a `(*objeto).something()`.
 >
-> Rust doesn’t have an equivalent to the `->` operator; instead, Rust has a
-> feature called *automatic referencing and dereferencing*. Calling methods is
-> one of the few places in Rust that has this behavior.
+> Rust no tiene un equivalente al operador `->`; en su lugar, Rust tiene una
+> característica llamada *referenciamiento automático y dereferenciación*. Llamar métodos es
+> uno de los pocos lugares en Rust que tiene este comportamiento.
 >
-> Here’s how it works: when you call a method with `object.something()`, Rust
-> automatically adds in `&`, `&mut`, or `*` so `object` matches the signature of
-> the method. In other words, the following are the same:
+> Así es como funciona: cuando llamas a un método con `object.something()`, Rust
+> agrega automáticamente `&`, `&mut`, o `*` así que `object` coincide con la firma del
+> método. En otras palabras, lo siguiente es lo mismo:
 >
 > ```rust
 > # #[derive(Debug,Copy,Clone)]
@@ -111,21 +111,21 @@ provide.
 > (&p1).distance(&p2);
 > ```
 >
-> The first one looks much cleaner. This automatic referencing behavior works
-> because methods have a clear receiver—the type of `self`. Given the receiver
-> and name of a method, Rust can figure out definitively whether the method is
-> reading (`&self`), mutating (`&mut self`), or consuming (`self`). The fact
-> that Rust makes borrowing implicit for method receivers is a big part of
-> making ownership ergonomic in practice.
+> La primera parece mucho más limpia. Este comportamiento de referenciación automática funciona
+> porque los métodos tienen un receptor claro, el tipo de `self`. Dado el receptor
+> y el nombre de un método, Rust puede determinar definitivamente si el método está
+> leyendo (`&self`), mutando (`&mut self`) o consumiendo (`&self`). El hecho
+> de que Rust haga que el préstamo implícito para receptores de métodos sea implícit
+> o es una gran parte de hacer que la propiedad ergonómica en la práctica.
 
-### Methods with More Parameters
+### Métodos con Más Parámetros
 
-Let’s practice using methods by implementing a second method on the `Rectangle`
-struct. This time, we want an instance of `Rectangle` to take another instance
-of `Rectangle` and return `true` if the second `Rectangle` can fit completely
-within `self`; otherwise it should return `false`. That is, we want to be able
-to write the program shown in Listing 5-14, once we’ve defined the `can_hold`
-method:
+Practiquemos usando métodos implementando un segundo método en la estructura del
+`Rectangle`. Esta vez, queremos una instancia de `Rectangle` para tomar otra instancia
+de `Rectangle` y retornar `true` si el segundo `Rectangle` puede encajar completamente
+dentro de `self`; de lo contrario debería retornar `falso`. Es decir, queremos poder
+escribir el programa mostrado en el Listado 5-14, una vez que hayamos definido el método 
+`can_hold`:
 
 <span class="filename">Filename: src/main.rs</span>
 
@@ -140,31 +140,31 @@ fn main() {
 }
 ```
 
-<span class="caption">Listing 5-14: Demonstration of using the as-yet-unwritten
-`can_hold` method</span>
+<span class="caption">Listing 5-14: Listado 5-14: Demostración del uso del método
+`can_hold` aún no escrito</span>
 
-And the expected output would look like the following, because both dimensions
-of `rect2` are smaller than the dimensions of `rect1`, but `rect3` is wider
-than `rect1`:
+Y la salida esperada sería similar a la siguiente, porque ambas dimensiones
+de `rect2` son más pequeñas que las dimensiones de `rect1`, pero `rect3` es más ancha
+que `rect1`:
 
 ```text
 Can rect1 hold rect2? true
 Can rect1 hold rect3? false
 ```
 
-We know we want to define a method, so it will be within the `impl Rectangle`
-block. The method name will be `can_hold`, and it will take an immutable borrow
-of another `Rectangle` as a parameter. We can tell what the type of the
-parameter will be by looking at the code that calls the method:
-`rect1.can_hold(&rect2)` passes in `&rect2`, which is an immutable borrow to
-`rect2`, an instance of `Rectangle`. This makes sense because we only need to
-read `rect2` (rather than write, which would mean we’d need a mutable borrow),
-and we want `main` to retain ownership of `rect2` so we can use it again after
-calling the `can_hold` method. The return value of `can_hold` will be a
-Boolean, and the implementation will check whether the width and height of
-`self` are both greater than the width and height of the other `Rectangle`,
-respectively. Let’s add the new `can_hold` method to the `impl` block from
-Listing 5-13, shown in Listing 5-15:
+Sabemos que queremos definir un método, por lo que estará dentro del bloque 
+`impl Rectangle`. El nombre del método será `can_hold`, y tomará un préstamo inmutable
+de otro `Rectangle` como parámetro. Podemos saber cuál será el tipo de
+parámetro al mirar el código que llama al método:
+`rect1.can_hold(&rect2)` pasa en `&rect2`, que es un préstamo inmutable a 
+`rect2`, una instancia de `Rectangle`. Esto tiene sentido porque sólo necesitamos
+leer `rect2` (en lugar de escribir, lo que significaría que necesitaríamos un préstamo mutable),
+y queremos que `main` conserve la propiedad de `rect2` para que podamos volver a usarlo después
+de llamar al método `can_hold`. El valor de retorno de `can_hold` será
+Booleano, y la implementación comprobará si la anchura y la altura del 
+`self` son mayores que la anchura y la altura del otro `Rectangle`, 
+respectivamente. Agreguemos el nuevo método `can_hold` al bloque `impl` del
+Listado 5-13, mostrado en Listado 5-15:
 
 <span class="filename">Filename: src/main.rs</span>
 
@@ -186,28 +186,28 @@ impl Rectangle {
 }
 ```
 
-<span class="caption">Listing 5-15: Implementing the `can_hold` method on
-`Rectangle` that takes another `Rectangle` instance as a parameter</span>
+<span class="caption">Listado 5-15: Implementación del método `can_hold` en el 
+`Rectangle` que toma otra instancia de `Rectangle` como un parámetro</span>
 
-When we run this code with the `main` function in Listing 5-14, we’ll get our
-desired output. Methods can take multiple parameters that we add to the
-signature after the `self` parameter, and those parameters work just like
-parameters in functions.
+Cuando ejecutamos este código con la función `main` en Listado 5-14, obtendremos 
+la salida deseada. Los métodos pueden tomar múltiples parámetros que añadimos a la
+firma después del parámetro `self`, y esos parámetros funcionan igual que los
+parámetros en las funciones.
 
-### Associated Functions
+### Funciones asociadas
 
-Another useful feature of `impl` blocks is that we’re allowed to define
-functions within `impl` blocks that *don’t* take `self` as a parameter. These
-are called *associated functions* because they’re associated with the struct.
-They’re still functions, not methods, because they don’t have an instance of
-the struct to work with. You’ve already used the `String::from` associated
-function.
+Otra característica útil de los bloques `impl` es que se nos permite definir 
+funciones dentro de bloques `impl` que *no* se toman como un parámetro `self`. Estas 
+funciones se denominan *funciones asociadas* porque están asociadas a la estructura.
+Siguen siendo funciones, no métodos, porque no tienen una instancia de 
+la estructura con la que trabajar. Ya has utilizado la función `String::from`
+asociada.
 
-Associated functions are often used for constructors that will return a new
-instance of the struct. For example, we could provide an associated function
-that would have one dimension parameter and use that as both width and height,
-thus making it easier to create a square `Rectangle` rather than having to
-specify the same value twice:
+Las funciones asociadas se utilizan a menudo para constructores que devolverán una nueva 
+instancia de la estructura. Por ejemplo, podríamos proporcionar una función asociada
+que tendría un parámetro de una dimensión y usarlo como ancho y altura,
+haciendo así más fácil crear un cuadrado `Rectangle` en lugar de tener que
+especificar el mismo valor dos veces:
 
 <span class="filename">Filename: src/main.rs</span>
 
@@ -225,16 +225,16 @@ impl Rectangle {
 }
 ```
 
-To call this associated function, we use the `::` syntax with the struct name,
-like `let sq = Rectangle::square(3);`, for example. This function is
-namespaced by the struct: the `::` syntax is used for both associated functions
-and namespaces created by modules, which we’ll discuss in Chapter 7.
+Para llamar a esta función asociada, utilizamos la sintaxis `::` con el nombre de la estructura, 
+como `let sq = Rectangle::square(3); `, por ejemplo. Esta función está
+espaciada por el nombre de la estructura: la sintaxis `::` se utiliza tanto para las funciones asociadas
+como para los espacios de nombres creados por los módulos, que discutiremos en el Capítulo 7.
 
-### Multiple `impl` Blocks
+### Múltiples Bloques `impl`
 
-Each struct is allowed to have multiple `impl` blocks. For example, Listing
-5-15 is equivalent to the code shown in Listing 5-16, which has each method
-in its own `impl` block:
+Cada estructura puede tener múltiples bloques `impl`. Por ejemplo, el Listado
+5-15 es equivalente al código mostrado en el Listado 5-16, que tiene cada método
+en su propio bloque `impl`:
 
 ```rust
 # #[derive(Debug)]
@@ -256,21 +256,21 @@ impl Rectangle {
 }
 ```
 
-<span class="caption">Listing 5-16: Rewriting Listing 5-15 using multiple `impl`
-blocks</span>
+<span class="caption">Listado 5-16: Reescritura Listado 5-15 usando múltiples bloques 
+`impl`</span>
 
-There’s no reason to separate these methods into multiple `impl` blocks here,
-but it’s valid syntax. We will see a case when multiple `impl` blocks are useful
-in Chapter 10 when we discuss generic types and traits.
+No hay razón para separar estos métodos en bloques múltiples `impl` aquí,
+pero es sintaxis válida. Veremos un caso cuando los bloques múltiples `impl` son útiles 
+en el Capítulo 10 cuando discutamos tipos y rasgos genéricos.
 
-## Summary
+## Resumen
 
-Structs let us create custom types that are meaningful for our domain. By using
-structs, we can keep associated pieces of data connected to each other and name
-each piece to make our code clear. Methods let us specify the behavior that
-instances of our structs have, and associated functions let us namespace
-functionality that is particular to our struct without having an instance
-available.
+Las estructuras nos permiten crear tipos personalizados que son significativos para nuestro dominio. Mediante
+el uso de estructuras, podemos mantener las piezas de datos asociadas conectadas entre sí y nombrar
+cada pieza para hacer que nuestro código sea claro. Los métodos nos permiten especificar el comportamiento 
+que tienen las instancias de nuestras estructuras, y las funciones asociadas nos permiten la funcionalidad
+del espacio de nombres que es particular a nuestra estructura sin tener una instancia
+disponible.
 
-But structs aren’t the only way we can create custom types: let’s turn to
-Rust’s enum feature to add another tool to our toolbox.
+Pero las estructuras no son la única forma en que podemos crear tipos personalizados: pasemos a la 
+función de enumeración de Rust para añadir otra herramienta a nuestra caja de herramientas.


### PR DESCRIPTION
This is a partial translation of the file ch05-03-method-syntax.md, this is part 2 of 2.
- 1362 words
- Translated lines: 61- 276

